### PR TITLE
Set img width for api content

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -15,6 +15,6 @@ pre { background-color:  white; margin-bottom: 1rem !important; }
 .side-panel a { padding-left: 0; }
 .side-panel h5 { margin: 1rem 0 1rem 0; }
 .side-panel h5 a { color: #000; }
-.api-content img { width: %; margin: 1rem 5%; }
+.api-content img { width: 100%; margin: 1rem 0; }
 .graphql img { width: 100%; margin: 1rem 0; }
 .language-javascript .err { background-color: transparent; }


### PR DESCRIPTION
Currently, the width of the diagram images for api content exceeds the screen size.

For example: https://developer.makerdao.com/dai/1/api/bite