### PR TITLE
Fix broken price feed link

### DIFF
--- a/feeds/index.md
+++ b/feeds/index.md
@@ -45,7 +45,7 @@ are deployed and owned by feed operators. Price feed contracts which have been
 whitelisted by the `medianizer` are able to forward their prices for inclusion in
 the medianized price.
 
-[price feed]: https://github/com/makerdao/price-feed
+[price feed]: https://github.com/makerdao/price-feed
 
 #### The Medianizer
 


### PR DESCRIPTION
Noticed a broken link when reading some documentation. This PR fixes it.