### PR TITLE
add api v1 depricated warning to oasis pages

### DIFF
--- a/_layouts/oasis/api.html
+++ b/_layouts/oasis/api.html
@@ -37,6 +37,12 @@
             </ul>
           </div>
           <div class="col-sm-9 api-content">
+            {% if page.apiVersion == 1 %}
+            <div class="alert alert-danger text-center mb-4" role="alert">
+              <h4 class="alert-heading">WARNING Oasis API v1 will be DEPRECATED</h4>
+              <p class="lead">Please start using <a class="alert-link" href="oasis/api/2/">API v2</a></p>
+            </div>
+            {% endif %}
             {{ content }}
           </div>
         </div>


### PR DESCRIPTION
Adding a warning to the top of Oasis v1 pages that the API will be deprecated:
![image](https://user-images.githubusercontent.com/1408372/62901157-533f4c00-bd19-11e9-8a3c-cf7c175ee689.png)
